### PR TITLE
Extend ABORT_ON_ENDSTOP_HIT to USB-printing

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -322,13 +322,15 @@
   // This allows hosts to request long names for files and folders with M33
   //#define LONG_FILENAME_HOST_SUPPORT
 
-  // This option allows you to abort SD printing when any endstop is triggered.
-  // This feature must be enabled with "M540 S1" or from the LCD menu.
-  // To have any effect, endstops must be enabled during SD printing.
-  // With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
-  //#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
-
 #endif // SDSUPPORT
+
+// This option allows you to abort printing when any endstop is triggered.
+// This feature must be enabled with "M540 S1" or from the LCD menu
+// or by #define ABORT_ON_ENDSTOP_HIT_INIT true.
+// To have any effect, endstops must be enabled during printing.
+// With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
+//#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
+//#define ABORT_ON_ENDSTOP_HIT_INIT true
 
 // for dogm lcd displays you can choose some additional fonts:
 #if ENABLED(DOGLCD)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -196,7 +196,7 @@
  * M501 - Read parameters from EEPROM (if you need reset them after you changed them temporarily).
  * M502 - Revert to the default "factory settings". You still need to store them in EEPROM afterwards if you want to.
  * M503 - Print the current settings (from memory not from EEPROM). Use S0 to leave off headings.
- * M540 - Use S[0|1] to enable or disable the stop SD card print on endstop hit (requires ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED)
+ * M540 - Use S[0|1] to enable or disable the stop print on endstop hit (requires ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED)
  * M600 - Pause for filament change X[pos] Y[pos] Z[relative lift] E[initial retract] L[later retract distance for removal]
  * M665 - Set delta configurations: L<diagonal rod> R<delta radius> S<segments/s>
  * M666 - Set delta endstop adjustment
@@ -246,7 +246,7 @@ float current_position[NUM_AXIS] = { 0.0 };
 static float destination[NUM_AXIS] = { 0.0 };
 bool axis_known_position[3] = { false };
 
-static long gcode_N, gcode_LastN, Stopped_gcode_LastN = 0;
+static long gcode_N, gcode_LastN; //Stopped_gcode_LastN = 0; unused
 
 static char* current_command, *current_command_args;
 static int cmd_queue_index_r = 0;
@@ -1872,24 +1872,10 @@ static void homeaxis(AxisEnum axis) {
     current_position[axis] = 0;
     sync_plan_position();
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (marlin_debug_flags & DEBUG_LEVELING) {
-        SERIAL_ECHOLNPGM("> enable_endstops(false)");
-      }
-    #endif
-    enable_endstops(false); // Disable endstops while moving away
-
     // Move away from the endstop by the axis HOME_BUMP_MM
     destination[axis] = -home_bump_mm(axis) * axis_home_dir;
     line_to_destination();
     st_synchronize();
-
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (marlin_debug_flags & DEBUG_LEVELING) {
-        SERIAL_ECHOLNPGM("> enable_endstops(true)");
-      }
-    #endif
-    enable_endstops(true); // Enable endstops for next homing move
 
     // Slow down the feedrate for the next move
     set_homing_bump_feedrate(axis);
@@ -1898,6 +1884,7 @@ static void homeaxis(AxisEnum axis) {
     destination[axis] = 2 * home_bump_mm(axis) * axis_home_dir;
     line_to_destination();
     st_synchronize();
+    endstops_hit_on_purpose(); // clear endstop hit flags
 
     #if ENABLED(DEBUG_LEVELING_FEATURE)
       if (marlin_debug_flags & DEBUG_LEVELING) {
@@ -1933,12 +1920,6 @@ static void homeaxis(AxisEnum axis) {
     #if ENABLED(DELTA)
       // retrace by the amount specified in endstop_adj
       if (endstop_adj[axis] * axis_home_dir < 0) {
-        #if ENABLED(DEBUG_LEVELING_FEATURE)
-          if (marlin_debug_flags & DEBUG_LEVELING) {
-            SERIAL_ECHOLNPGM("> enable_endstops(false)");
-          }
-        #endif
-        enable_endstops(false); // Disable endstops while moving away
         sync_plan_position();
         destination[axis] = endstop_adj[axis];
         #if ENABLED(DEBUG_LEVELING_FEATURE)
@@ -1949,12 +1930,6 @@ static void homeaxis(AxisEnum axis) {
         #endif
         line_to_destination();
         st_synchronize();
-        #if ENABLED(DEBUG_LEVELING_FEATURE)
-          if (marlin_debug_flags & DEBUG_LEVELING) {
-            SERIAL_ECHOLNPGM("> enable_endstops(true)");
-          }
-        #endif
-        enable_endstops(true); // Enable endstops for next homing move
       }
       #if ENABLED(DEBUG_LEVELING_FEATURE)
         else {
@@ -7191,7 +7166,7 @@ void Stop() {
   disable_all_heaters();
   if (IsRunning()) {
     Running = false;
-    Stopped_gcode_LastN = gcode_LastN; // Save last g_code for restart
+    //Stopped_gcode_LastN = gcode_LastN; // Save last g_code for restart
     SERIAL_ERROR_START;
     SERIAL_ERRORLNPGM(MSG_ERR_STOPPED);
     LCD_MESSAGEPGM(MSG_STOPPED);


### PR DESCRIPTION
Added configurable option ABORT_ON_ENDSTOP_HIT_INIT to activate the feature at boot time.
Changes some descriptive text.
Cleaned up the use of enable_endstops() in homeaxis().
Changed the initialisation of abort_on_endstop_hit to relate on ABORT_ON_ENDSTOP_HIT_INIT.
Changed checkHitEndstops() to
throw an ERROR instead of an ECHO when ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED.
Send "X=" instead of "X:" also for Y,Z and probe to make the output not readable by Repetier Host.

Abort all printing when ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED. Therefor the already existent feature for sd-printing was extended.

To come out of the look send M999.
