### PR TITLE
Fix crashes when the Z axis is moved via LCD

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -830,11 +830,15 @@ static void _lcd_move(const char* name, AxisEnum axis, int min, int max) {
     if (min_software_endstops && current_position[axis] < min) current_position[axis] = min;
     if (max_software_endstops && current_position[axis] > max) current_position[axis] = max;
     encoderPosition = 0;
-    line_to_current(axis);
+    if (movesplanned() <= 3)
+      line_to_current(axis);
     lcdDrawUpdate = 1;
   }
   if (lcdDrawUpdate) lcd_implementation_drawedit(name, ftostr31(current_position[axis]));
-  if (LCD_CLICKED) lcd_goto_menu(lcd_move_menu_axis);
+  if (LCD_CLICKED) {
+      line_to_current(axis);
+      lcd_goto_menu(lcd_move_menu_axis);
+  }
 }
 static void lcd_move_x() { _lcd_move(PSTR(MSG_MOVE_X), X_AXIS, X_MIN_POS, X_MAX_POS); }
 static void lcd_move_y() { _lcd_move(PSTR(MSG_MOVE_Y), Y_AXIS, Y_MIN_POS, Y_MAX_POS); }


### PR DESCRIPTION
Fix crashes when the Z axis is moved via LCD
by calling `plan_buffer_line` only when there is enough room in the
planner buffer, to avoid endless recursion.
A brief description about what propably went wrong is in #1166
